### PR TITLE
applied desktopentry patch from suckless.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,9 +49,12 @@ install: st
 	chmod 644 $(DESTDIR)$(MANPREFIX)/man1/st.1
 	tic -sx st.info
 	@echo Please see the README file regarding the terminfo entry of st.
+	mkdir -p $(DESTDIR)$(PREFIX)/share/applications
+	cp -f st.desktop $(DESTDIR)$(PREFIX)/share/applications
 
 uninstall:
 	rm -f $(DESTDIR)$(PREFIX)/bin/st
 	rm -f $(DESTDIR)$(MANPREFIX)/man1/st.1
+	rm -f $(DESTDIR)$(PREFIX)/share/applications/st.desktop
 
 .PHONY: all options clean dist install uninstall

--- a/st.desktop
+++ b/st.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Type=Application
+Name=st
+Comment=simple-terminal emulator for X
+Icon=utilities-terminal
+Exec=st
+Categories=System;TerminalEmulator


### PR DESCRIPTION
# Description

By default st is installed silently without a `.desktop` file entry in the applications folder and this doesn't let programs like rofi detect this program in `drun` mode.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This modification has been tested personally by me after installing it locally and running it on my machine.

- [x] Test 1: Checked applications folder for `.desktop` entry
- [x] Test 2: Checked whether rofi detected st

**Test Configuration**:
* Kernel version: 5.4.64-gentoo
* X-Server version: 1.20.8-r1
* Compositor: picom

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
